### PR TITLE
Add changelog building and output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,26 @@ jobs:
 | `patchList` | Comma separated commit prefixes, used to bump Patch version.                                                                               |         :x:        | `fix, bugfix, perf, refactor, test, tests` |
 | `patchAll`  | If set to `true`, will ignore `patchList` and always count commits as a Patch.                                                             |         :x:        | `false`                                    |
 
+### Changelog inputs
+
+- `majorTitle` Optional title of the breaking change section. If set blank, won't be rendered. If unset, will render default.
+- `majorEmoji` Optional emoji code to prefix `majorTitle` text. If set blank, won't be rendered. If unset, will render default.
+- `minorTitle` Optional title of the new features section. If set blank, won't be rendered. If unset, will render default.
+- `minorEmoji` Optional emoji code to prefix `minorTitle` text. If set blank, won't be rendered. If unset, will render default.
+- `patchTitle` Optional title of patch's section. If set blank, won't be rendered. If unset, will render default.
+- `patchEmoji` Optional emoji code to prefix `patchTitle` text. If set blank, won't be rendered. If unset, will render default.
+- `contributorsTitle` Optional title of patch's section. If set blank, won't be rendered. If unset, will render default.
+- `contributorsEmoji` Optional emoji code to prefix `contributorsTitle` text. If set blank, won't be rendered. If unset, will render default.
+
 ## Outputs
 
-| Field        | Description                                 | Example Value |
-|--------------|---------------------------------------------|---------------|
-| `current`    | Current version number / latest tag.        | `v1.1.9`      |
-| `next`       | Next version number in format `v0.0.0`      | `v1.2.0`      |
-| `nextStrict` | Next version number without the `v` prefix. | `1.2.0`       |
+| Field        | Description                                 |  Example Value  |
+|--------------|---------------------------------------------|-----------------|
+| `current`    | Current version number / latest tag.        |  `v1.1.9`       |
+| `next`       | Next version number in format `v0.0.0`      |  `v1.2.0`       |
+| `nextStrict` | Next version number without the `v` prefix. |  `1.2.0`        |
+| `changeLog`  | Change log text, that can be used as        |  `# Release...` |
+|              | release notes.                              |                 |
 
 ## :warning: Important :warning:
 

--- a/action.yml
+++ b/action.yml
@@ -13,18 +13,50 @@ inputs:
     description: Comma separated commit prefixes, used to bump Major version
     required: false
     default: ''
+  majorTitle:
+    description: Title to be used in release notes for Major version
+    required: false
+    default: 'Breaking Changes'
+  majorEmoji:
+    description: Emoji to be used next to Major Title
+    required: false
+    default: ':chart_with_upwards_trend:'
   minorList:
     description: Comma separated commit prefixes, used to bump Minor version
     required: false
     default: feat, feature
+  minorTitle:
+    description: Title to be used in release notes for Minor version
+    required: false
+    default: "New Features"
+  minorEmoji:
+    description: Emoji to be used next to Minor Title
+    required: false
+    default: ":star:"
   patchList:
     description: Comma separated commit prefixes, used to bump Patch version
     required: false
     default: fix, bugfix, perf, refactor, test, tests
+  patchTitle:
+    description: Title to be used in release notes for Patch version
+    required: false
+    default: "Other Changes"
+  patchEmoji:
+    description: Emoji to be used next to Patch Title
+    required: false
+    default: ":lady_beetle:"
   patchAll:
     description: If set to true, will ignore patchList and count any commit as a Patch
     required: false
     default: false
+  contributorsTitle:
+    description: Title to be used in release notes for Contributors section
+    required: false
+    default: "Contributors"
+  contributorsEmoji:
+    description: Emoji to be used next to Contributors section
+    required: false
+    default: ":heart:"
 outputs:
   current:
     description: Current version number
@@ -32,6 +64,8 @@ outputs:
     description: Next version number in format v0.0.0
   nextStrict:
     description: Next version number without the v prefix
+  changeLog:
+    description: Changelog body for optional usage
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29753,7 +29753,7 @@ async function main () {
 
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
-    ajorTitle: core.getInput('majorTitle').trim(),
+    majorTitle: core.getInput('majorTitle').trim(),
     majorEmoji: core.getInput('majorEmoji').trim(),
     minor: core.getInput('minorList').split(',').map(p => p.trim()).filter(p => p),
     minorTitle: core.getInput('minorTitle').trim(),
@@ -29876,7 +29876,7 @@ async function main () {
       }
       for (const note of cAst.notes) {
         if (note.title === 'BREAKING CHANGE') {
-          processCommit(commit, patchChanges, cAst.type, 'major', true)
+          processCommit(commit, majorChanges, cAst.type, 'major', true)
           processContributors(commit, contributors)
         }
       }
@@ -29940,7 +29940,7 @@ async function main () {
     return section
   }
 
-  var changeLog = `# Release v${next}%0A%0A`;
+  let changeLog = `# Release v${next}%0A%0A`;
   if (majorChanges.length > 0 && bumpTypes.majorTitle.length > 0) {
     changeLog += buildVersionSection(bumpTypes.majorTitle, majorChanges, bumpTypes.majorEmoji)
   }

--- a/index.js
+++ b/index.js
@@ -13,9 +13,17 @@ async function main () {
 
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
+    ajorTitle: core.getInput('majorTitle').trim(),
+    majorEmoji: core.getInput('majorEmoji').trim(),
     minor: core.getInput('minorList').split(',').map(p => p.trim()).filter(p => p),
+    minorTitle: core.getInput('minorTitle').trim(),
+    minorEmoji: core.getInput('minorEmoji').trim(),
     patch: core.getInput('patchList').split(',').map(p => p.trim()).filter(p => p),
+    patchTitle: core.getInput('patchTitle').trim(),
+    patchEmoji: core.getInput('patchEmoji').trim(),
     patchAll: (core.getInput('patchAll') === true || core.getInput('patchAll') === 'true'),
+    contributorsTitle: core.getInput('contributorsTitle').trim(),
+    contributorsEmoji: core.getInput('contributorsEmoji').trim(),
   }
 
   // GET LATEST + PREVIOUS TAGS
@@ -79,25 +87,57 @@ async function main () {
   const majorChanges = []
   const minorChanges = []
   const patchChanges = []
+  const contributors = []
+
+  let processCommit = (commit, versionChanges, typeName, versionName, isBreakChange = false) => {
+    versionChanges.push(commit.commit.message)
+
+    let infoTxt = `[${versionName.toUpperCase()}] Commit ${commit.sha} `
+    if (isBreakChange) {
+      infoTxt += `has a BREAKING CHANGE mention, causing`
+    } else {
+      infoTxt += `of type ${typeName} will cause`
+    }
+    infoTxt += ` a ${versionName.toLowerCase()} version bump.`
+
+    core.info(infoTxt)
+  };
+
+  let processContributors = (commit, committers) => {
+
+    let existingAuthor = committers.find((item, index) => {
+      return (item.email === commit.commit.author.email)
+    })
+
+    if (typeof existingAuthor === 'undefined') {
+      committers.push({
+        "name": commit.commit.author.name,
+        "email": commit.commit.author.email,
+        "login": commit.author !== null ? commit.author.login : null,
+        "url": commit.author !== null ? commit.author.html_url : null
+      })
+    }
+  };
+
   for (const commit of commits) {
     try {
       const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
       if (bumpTypes.major.includes(cAst.type)) {
-        majorChanges.push(commit.commit.message)
-        core.info(`[MAJOR] Commit ${commit.sha} of type ${cAst.type} will cause a major version bump.`)
+        processCommit(commit, majorChanges, cAst.type, 'major')
+        processContributors(commit, contributors)
       } else if (bumpTypes.minor.includes(cAst.type)) {
-        minorChanges.push(commit.commit.message)
-        core.info(`[MINOR] Commit ${commit.sha} of type ${cAst.type} will cause a minor version bump.`)
+        processCommit(commit, minorChanges, cAst.type, 'minor')
+        processContributors(commit, contributors)
       } else if (bumpTypes.patchAll || bumpTypes.patch.includes(cAst.type)) {
-        patchChanges.push(commit.commit.message)
-        core.info(`[PATCH] Commit ${commit.sha} of type ${cAst.type} will cause a patch version bump.`)
+        processCommit(commit, patchChanges, cAst.type, 'patch')
+        processContributors(commit, contributors)
       } else {
         core.info(`[SKIP] Commit ${commit.sha} of type ${cAst.type} will not cause any version bump.`)
       }
       for (const note of cAst.notes) {
         if (note.title === 'BREAKING CHANGE') {
-          majorChanges.push(commit.commit.message)
-          core.info(`[MAJOR] Commit ${commit.sha} has a BREAKING CHANGE mention, causing a major version bump.`)
+          processCommit(commit, patchChanges, cAst.type, 'major', true)
+          processContributors(commit, contributors)
         }
       }
     } catch (err) {
@@ -124,9 +164,64 @@ async function main () {
   core.info(`Current version is ${latestTag.name}`)
   core.info(`Next version is v${next}`)
 
+  // BUILD CHANGELOG
+
+  buildVersionSection = (title, entries, emoji) => {
+    let section = '## ';
+    if (emoji.length > 0) {
+      section += `${emoji} `;
+    }
+    section += `${title}%0A%0A `;
+
+    entries.forEach((entry) => {
+      section += `- ${entry}%0A `;
+    })
+    section += `%0A `;
+
+    return section
+  }
+
+  buildContributorsSection = (title, contributors, emoji) => {
+    let section = '## ';
+    if (emoji.length > 0) {
+      section += `${emoji} `;
+    }
+    section += `${title}%0A%0A `;
+
+    contributors.forEach((author) => {
+      if (author.login !== null && author.url !== null) {
+        section += `- [@${author.login}](${author.url}) ${author.name}%0A `;
+      } else {
+        section += `- ${author.name}%0A `;
+      }
+    })
+    section += `%0A `;
+
+    return section
+  }
+
+  var changeLog = `# Release v${next}%0A%0A`;
+  if (majorChanges.length > 0 && bumpTypes.majorTitle.length > 0) {
+    changeLog += buildVersionSection(bumpTypes.majorTitle, majorChanges, bumpTypes.majorEmoji)
+  }
+  if (minorChanges.length > 0 && bumpTypes.minorTitle.length > 0) {
+    changeLog += buildVersionSection(bumpTypes.minorTitle, minorChanges, bumpTypes.minorEmoji)
+  }
+  if (patchChanges.length > 0 && bumpTypes.patchTitle.length > 0) {
+    changeLog += buildVersionSection(bumpTypes.patchTitle, patchChanges, bumpTypes.patchEmoji)
+  }
+  if (contributors.length > 0 && bumpTypes.contributorsTitle.length > 0) {
+    changeLog += buildContributorsSection(bumpTypes.contributorsTitle, contributors, bumpTypes.contributorsEmoji)
+  }
+
+  core.info(`Change log is %0A${changeLog}%0A`)
+
+  // EXPORT VALUES
+
   core.exportVariable('current', latestTag.name)
   core.exportVariable('next', `v${next}`)
   core.exportVariable('nextStrict', next)
+  core.exportVariable('changeLog', changeLog)
 }
 
 main()

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ async function main () {
 
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
-    ajorTitle: core.getInput('majorTitle').trim(),
+    majorTitle: core.getInput('majorTitle').trim(),
     majorEmoji: core.getInput('majorEmoji').trim(),
     minor: core.getInput('minorList').split(',').map(p => p.trim()).filter(p => p),
     minorTitle: core.getInput('minorTitle').trim(),
@@ -136,7 +136,7 @@ async function main () {
       }
       for (const note of cAst.notes) {
         if (note.title === 'BREAKING CHANGE') {
-          processCommit(commit, patchChanges, cAst.type, 'major', true)
+          processCommit(commit, majorChanges, cAst.type, 'major', true)
           processContributors(commit, contributors)
         }
       }
@@ -200,7 +200,7 @@ async function main () {
     return section
   }
 
-  var changeLog = `# Release v${next}%0A%0A`;
+  let changeLog = `# Release v${next}%0A%0A`;
   if (majorChanges.length > 0 && bumpTypes.majorTitle.length > 0) {
     changeLog += buildVersionSection(bumpTypes.majorTitle, majorChanges, bumpTypes.majorEmoji)
   }


### PR DESCRIPTION
Hi @NGPixel ,

I didn't add the Changelog configuration inputs to the main table, due to configuration issues.
Maybe you can do it better than I can.
... I've added the information below, though.

Icons and section titles are editable via inputs.
If titles are set blank (_empty string_), section won't be rendered. Same with Contributor's section.

If Contributor's detailed information can be retrieved, an User handler with a link to the contributor's page will be rendered. Otherwise, just the name.
These won't be duplicated (_several commits by same author_).

This will produce the result in the release note's body, as below:
![image](https://user-images.githubusercontent.com/8511557/161144911-f16d2fe2-b0bf-4cb9-a005-6841eb2941fb.png)

Thanks.