### PR TITLE
fix: bug with additional commits message not parsed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: Whether to exit with an error, warning or silently when none of the commits result in a version bump. (error, warn, current, silent)
     required: false
     default: error
+  preReleaseStage:
+    description: The Pre Release Stage to use, (rc, beta, alpha, etc)
+    required: false
+    default: none
   prefix:
     description: A prefix that will be ignored when parsing tags. Useful for monorepos. The prefix will be added back to the output values.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ outputs:
     description: Next version major number in format v0
   nextMajorStrict:
     description: Next version major number only.
+  versionType:
+    description: The type of version bump
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -31051,6 +31051,7 @@ async function main () {
   const repo = github.context.repo.repo
   const skipInvalidTags = core.getBooleanInput('skipInvalidTags')
   const noVersionBumpBehavior = core.getInput('noVersionBumpBehavior')
+  const preReleaseStage = core.getInput('preReleaseStage') || 'none'
   const prefix = core.getInput('prefix') || ''
   const additionalCommits = core.getInput('additionalCommits').split('\n').map(l => l.trim()).filter(l => l !== '')
 
@@ -31222,13 +31223,13 @@ async function main () {
       }
     }
   }
-
+  if (preReleaseStage != 'none') bump = `pre${bump}`;
   core.setOutput('versionType', bump)
   core.info(`\n>>> Will bump version ${prefix}${latestTag.name} using ${bump.toUpperCase()}\n`)
 
   // BUMP VERSION
 
-  const next = semver.inc(latestTag.name, bump)
+  const next = preReleaseStage == 'none'? semver.inc(latestTag.name, bump): semver.inc(latestTag.name, bump, preReleaseStage);
 
   core.info(`Current version is ${prefix}${latestTag.name}`)
   core.info(`Next version is ${prefix}v${next}`)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ async function main () {
   const prefix = core.getInput('prefix') || ''
   const additionalCommits = core.getInput('additionalCommits').split('\n').map(l => l.trim()).filter(l => l !== '')
 
+  core.debug(`Parsed additional commits as ${JSON.stringify(additionalCommits)}`)
+
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
     minor: core.getInput('minorList').split(',').map(p => p.trim()).filter(p => p),
@@ -120,29 +122,39 @@ async function main () {
   const majorChanges = []
   const minorChanges = []
   const patchChanges = []
+
+  core.info(`Found ${commits.length} commits between HEAD and latest tag.`)
   for (const commit of commits) {
+    const commitMessage = commit?.commit?.message ?? commit
+    const commitSha = commit?.sha ?? 'unknown'
     try {
-      const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
+      core.debug(`Parsing commit ${commitSha} (${commitMessage})`)
+      // additional commits are simple strings and not objects
+      const ast = cc.parser(commitMessage);
+      core.debug(`Parsed commit ${commitSha} as ${JSON.stringify(ast)}`)
+      const cAst = cc.toConventionalChangelogFormat(ast);
+      core.debug(`Converted commit ${commitSha} to ${JSON.stringify(cAst)}`)
       if (bumpTypes.major.includes(cAst.type)) {
-        majorChanges.push(commit.commit.message)
-        core.info(`[MAJOR] Commit ${commit.sha} of type ${cAst.type} will cause a major version bump.`)
+        majorChanges.push(commitMessage)
+        core.info(`[MAJOR] Commit ${commitSha} of type ${cAst.type} will cause a major version bump.`)
       } else if (bumpTypes.minor.includes(cAst.type)) {
-        minorChanges.push(commit.commit.message)
-        core.info(`[MINOR] Commit ${commit.sha} of type ${cAst.type} will cause a minor version bump.`)
+        minorChanges.push(commitMessage)
+        core.info(`[MINOR] Commit ${commitSha} of type ${cAst.type} will cause a minor version bump.`)
       } else if (bumpTypes.patchAll || bumpTypes.patch.includes(cAst.type)) {
-        patchChanges.push(commit.commit.message)
-        core.info(`[PATCH] Commit ${commit.sha} of type ${cAst.type} will cause a patch version bump.`)
+        patchChanges.push(commitMessage)
+        core.info(`[PATCH] Commit ${commitSha} of type ${cAst.type} will cause a patch version bump.`)
       } else {
-        core.info(`[SKIP] Commit ${commit.sha} of type ${cAst.type} will not cause any version bump.`)
+        core.info(`[SKIP] Commit ${commitSha} of type ${cAst.type} will not cause any version bump.`)
       }
       for (const note of cAst.notes) {
         if (note.title === 'BREAKING CHANGE') {
-          majorChanges.push(commit.commit.message)
-          core.info(`[MAJOR] Commit ${commit.sha} has a BREAKING CHANGE mention, causing a major version bump.`)
+          majorChanges.push(commitMessage)
+          core.info(`[MAJOR] Commit ${commitSha} has a BREAKING CHANGE mention, causing a major version bump.`)
         }
       }
     } catch (err) {
-      core.info(`[INVALID] Skipping commit ${commit.sha} as it doesn't follow conventional commit format.`)
+      core.warning(`[INVALID] Skipping commit ${commitSha} (${commitMessage}) as it doesn't follow conventional commit format.`)
+      core.debug(err)
     }
   }
 
@@ -171,6 +183,8 @@ async function main () {
       }
     }
   }
+
+  core.setOutput('versionType', bump)
   core.info(`\n>>> Will bump version ${prefix}${latestTag.name} using ${bump.toUpperCase()}\n`)
 
   // BUMP VERSION

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ async function main () {
   const repo = github.context.repo.repo
   const skipInvalidTags = core.getBooleanInput('skipInvalidTags')
   const noVersionBumpBehavior = core.getInput('noVersionBumpBehavior')
+  const preReleaseStage = core.getInput('preReleaseStage') || 'none'
   const prefix = core.getInput('prefix') || ''
   const additionalCommits = core.getInput('additionalCommits').split('\n').map(l => l.trim()).filter(l => l !== '')
 
@@ -183,13 +184,13 @@ async function main () {
       }
     }
   }
-
+  if (preReleaseStage != 'none') bump = `pre${bump}`;
   core.setOutput('versionType', bump)
   core.info(`\n>>> Will bump version ${prefix}${latestTag.name} using ${bump.toUpperCase()}\n`)
 
   // BUMP VERSION
 
-  const next = semver.inc(latestTag.name, bump)
+  const next = preReleaseStage == 'none'? semver.inc(latestTag.name, bump): semver.inc(latestTag.name, bump, preReleaseStage);
 
   core.info(`Current version is ${prefix}${latestTag.name}`)
   core.info(`Next version is ${prefix}v${next}`)


### PR DESCRIPTION
This patch is a fix for a bug with additional Commits where the commit message were not being passed to the parser correctly, this then caused an error when trying to parse the commit message.

This patch also add a new output to the action called `versionType` which will return the type of version that was bumped. This will be useful for other actions to use.

also includes debug logs for the action, these were useful in debug our issue.