### PR TITLE
fix: add prefix to call to compareCommitsWithBasehead

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31043,7 +31043,7 @@ const _ = __nccwpck_require__(250)
 const cc = __nccwpck_require__(4523)
 const semver = __nccwpck_require__(1383)
 
-async function main() {
+async function main () {
   const token = core.getInput('token')
   const branch = core.getInput('branch')
   const gh = github.getOctokit(token)
@@ -31062,7 +31062,7 @@ async function main() {
     patchAll: (core.getInput('patchAll') === true || core.getInput('patchAll') === 'true'),
   }
 
-  function outputVersion(version) {
+  function outputVersion (version) {
     core.exportVariable('next', `${prefix}v${version}`)
     core.exportVariable('nextStrict', `${prefix}${version}`)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -31043,7 +31043,7 @@ const _ = __nccwpck_require__(250)
 const cc = __nccwpck_require__(4523)
 const semver = __nccwpck_require__(1383)
 
-async function main () {
+async function main() {
   const token = core.getInput('token')
   const branch = core.getInput('branch')
   const gh = github.getOctokit(token)
@@ -31062,7 +31062,7 @@ async function main () {
     patchAll: (core.getInput('patchAll') === true || core.getInput('patchAll') === 'true'),
   }
 
-  function outputVersion (version) {
+  function outputVersion(version) {
     core.exportVariable('next', `${prefix}v${version}`)
     core.exportVariable('nextStrict', `${prefix}${version}`)
 
@@ -31171,7 +31171,7 @@ async function main () {
     const commitsRaw = await gh.rest.repos.compareCommitsWithBasehead({
       owner,
       repo,
-      basehead: `${latestTag.name}...${branch}`,
+      basehead: `${prefix}${latestTag.name}...${branch}`,
       page: curPage,
       per_page: 100
     })

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const cc = require('@conventional-commits/parser')
 const semver = require('semver')
 
-async function main() {
+async function main () {
   const token = core.getInput('token')
   const branch = core.getInput('branch')
   const gh = github.getOctokit(token)
@@ -23,7 +23,7 @@ async function main() {
     patchAll: (core.getInput('patchAll') === true || core.getInput('patchAll') === 'true'),
   }
 
-  function outputVersion(version) {
+  function outputVersion (version) {
     core.exportVariable('next', `${prefix}v${version}`)
     core.exportVariable('nextStrict', `${prefix}${version}`)
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const _ = require('lodash')
 const cc = require('@conventional-commits/parser')
 const semver = require('semver')
 
-async function main () {
+async function main() {
   const token = core.getInput('token')
   const branch = core.getInput('branch')
   const gh = github.getOctokit(token)
@@ -23,7 +23,7 @@ async function main () {
     patchAll: (core.getInput('patchAll') === true || core.getInput('patchAll') === 'true'),
   }
 
-  function outputVersion (version) {
+  function outputVersion(version) {
     core.exportVariable('next', `${prefix}v${version}`)
     core.exportVariable('nextStrict', `${prefix}${version}`)
 
@@ -132,7 +132,7 @@ async function main () {
     const commitsRaw = await gh.rest.repos.compareCommitsWithBasehead({
       owner,
       repo,
-      basehead: `${latestTag.name}...${branch}`,
+      basehead: `${prefix}${latestTag.name}...${branch}`,
       page: curPage,
       per_page: 100
     })


### PR DESCRIPTION
To resolve [issue #31](https://github.com/ietf-tools/semver-action/issues/31).

This adds ${prefix} into the call to compareCommitsWithBasehead. 

