### PR TITLE
feat: add tagFilter setting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,9 @@ inputs:
     description: Maximum number of tags to fetch from latest.
     required: false
     default: '10'
+  tagFilter:
+    description: Regex pattern used to filter out tags that should be ignored.
+    required: false
 outputs:
   current:
     description: Current version number / latest tag.

--- a/dist/index.js
+++ b/dist/index.js
@@ -52962,6 +52962,7 @@ async function main () {
   const fromTag = core.getInput('fromTag')
   const maxTagsToFetch = _.toSafeInteger(core.getInput('maxTagsToFetch') || 10)
   const fetchLimit = (maxTagsToFetch < 1 || maxTagsToFetch > 100) ? 10 : maxTagsToFetch
+  const tagFilter = core.getInput('tagFilter')
 
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
@@ -53022,7 +53023,19 @@ async function main () {
     }
 
     let idx = 0
+
+    if (tagFilter) {
+      console.log('Will filter out tags that match: ' + tagFilter)
+    }
+
     for (const tag of tagsList) {
+      if (tagFilter) {
+        if (new RegExp(tagFilter).test(tag.name)) {
+          console.log(`Skipping tag "${tag.name}" (matches tagFilter)`)
+          continue
+        }
+      }
+
       if (prefix) {
         if (tag.name.indexOf(prefix) === 0) {
           tag.name = tag.name.replace(prefix, '')

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ async function main () {
   const fromTag = core.getInput('fromTag')
   const maxTagsToFetch = _.toSafeInteger(core.getInput('maxTagsToFetch') || 10)
   const fetchLimit = (maxTagsToFetch < 1 || maxTagsToFetch > 100) ? 10 : maxTagsToFetch
+  const tagFilter = core.getInput('tagFilter')
 
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
@@ -78,7 +79,19 @@ async function main () {
     }
 
     let idx = 0
+
+    if (tagFilter) {
+      console.log('Will filter out tags that match: ' + tagFilter)
+    }
+
     for (const tag of tagsList) {
+      if (tagFilter) {
+        if (new RegExp(tagFilter).test(tag.name)) {
+          console.log(`Skipping tag "${tag.name}" (matches tagFilter)`)
+          continue
+        }
+      }
+
       if (prefix) {
         if (tag.name.indexOf(prefix) === 0) {
           tag.name = tag.name.replace(prefix, '')


### PR DESCRIPTION
This PR introduces a new `tagFilter` setting that allows users to filter out tags from the version  checking logic. In our particular case, we have semver tags like `v1.2.4` and then we have auto-generated tags named `v1.2.4-chart`. This was causing the SemVer action logic to fail:

```
Run ietf-tools/semver-action@v1
Comparing against latest tag: v1.2.4-chart
[PATCH] ...

>>> Will bump version v1.2.4-chart using PATCH

Current version is v1.2.4-chart
Next version is v1.2.4
```

With this new setting in place, I can set `tagFilter: (.+)-(chart)` and then it filters that tag out and we get the next version we expect:

```
Run diranged/semver-action@filter
Will filter out tags that match: (.+)-(chart)
Skipping tag "v1.2.4-chart" (matches tagFilter)
Comparing against latest tag: v1.2.4
[PATCH] ...

>>> Will bump version v1.2.4 using PATCH

Current version is v1.2.4
Next version is v1.2.5
```