### PR TITLE
feat: Add Dynamic Prefix Ignoring for Commit Message

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,21 +54,22 @@ jobs:
 
 ## Inputs
 
-| Field       | Description                                                                                                                                |      Required      | Default                                    |
-|-------------|--------------------------------------------------------------------------------------------------------------------------------------------|:------------------:|--------------------------------------------|
-| `token`     | Your GitHub token. (e.g. `${{ github.token }}`)                                                                                            | :white_check_mark: |                                            |
-| `branch`    | The branch to use when fetching list of commits to compare against. (e.g. `main`)                                                          |         :x:        | `main`                                     |
-| `majorList` | Comma separated commit prefixes, used to bump Major version. <br>*A `BREAKING CHANGE` note in a commit message will still cause a major bump.* |         :x:        |                                            |
-| `minorList` | Comma separated commit prefixes, used to bump Minor version.                                                                               |         :x:        | `feat, feature`                            |
-| `patchList` | Comma separated commit prefixes, used to bump Patch version.                                                                               |         :x:        | `fix, bugfix, perf, refactor, test, tests` |
-| `patchAll`  | If set to `true`, will ignore `patchList` and always count commits as a Patch.                                                             |         :x:        | `false`                                    |
-| `skipInvalidTags` | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest). |         :x:        | `false`                                    |
+| Field              | Description                                                                                                                                |      Required      | Default                                    |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------|:------------------:|--------------------------------------------|
+| `token`            | Your GitHub token. (e.g. `${{ github.token }}`)                                                                                            | :white_check_mark: |                                            |
+| `branch`           | The branch to use when fetching list of commits to compare against. (e.g. `main`)                                                          |         :x:        | `main`                                     |
+| `majorList`        | Comma separated commit prefixes, used to bump Major version. <br>*A `BREAKING CHANGE` note in a commit message will still cause a major bump.* |         :x:        |                                            |
+| `minorList`        | Comma separated commit prefixes, used to bump Minor version.                                                                               |         :x:        | `feat, feature`                            |
+| `patchList`        | Comma separated commit prefixes, used to bump Patch version.                                                                               |         :x:        | `fix, bugfix, perf, refactor, test, tests` |
+| `patchAll`         | If set to `true`, will ignore `patchList` and always count commits as a Patch.                                                             |         :x:        | `false`                                    |
+| `skipInvalidTags`  | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest).                 |         :x:        | `false`                                    |
 | `noVersionBumpBehavior` | Whether to exit with an error *(default)*, a warning, silently, the current version or force bump using patch when none of the commits result in a version bump. (Possible values: `error`, `warn`, `current`, `patch` or `silent`) |         :x:        | `error` |
 | `noNewCommitBehavior` | Whether to exit with an error *(default)*, a warning, the current version or silently when there are no new commits since the latest tag. (Possible values: `error`, `warn`, `current` or `silent`) |         :x:        | `error` |
-| `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. |         :x:        |  |
-| `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: | |
-| `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: | |
-| `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10` |
+| `prefix`           | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. |         :x:        |  |
+| `additionalCommits`| A list of additional commit messages to parse in order to calculate semver. | :x: | |
+| `fromTag`          | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: | |
+| `maxTagsToFetch`   | Maximum number of tags to fetch from latest. | :x: | `10` |
+| `prefixIgnoreList` | Comma separated list of prefixes to ignore in commit messages when evaluating for semantic versioning. | :x: | |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'AdmirHad/Semver Conventional Commits'
-description: 'forked from ietf'
+name: 'Semver Conventional Commits'
+description: 'Calculate the next release version based on conventional commits since latest tag'
 author: Nicolas Giard
 inputs:
   token:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'Semver Conventional Commits'
-description: 'Calculate the next release version based on conventional commits since latest tag'
+name: 'AdmirHad/Semver Conventional Commits'
+description: 'forked from ietf'
 author: Nicolas Giard
 inputs:
   token:
@@ -52,6 +52,10 @@ inputs:
     description: Maximum number of tags to fetch from latest.
     required: false
     default: '10'
+  prefixIgnoreList:
+    description: Comma separated list of prefixes to ignore in commit messages when evaluating for semantic versioning. Supports wildcards like `*` and `?`.
+    required: false
+    default: ''
 outputs:
   current:
     description: Current version number / latest tag.

--- a/index.js
+++ b/index.js
@@ -201,8 +201,18 @@ async function main () {
   function parseCommitMessage(message, ignoreList) {
     let cleanedMessage = message;
     if (ignoreList && ignoreList.length > 0) {
-      const regex = new RegExp(`^(${ignoreList.join('|')})\\s*`, 'i');
-      cleanedMessage = message.replace(regex, '');
+      // Convert wildcard patterns to regex
+      const regexPatterns = ignoreList.map(pattern => {
+        const regexString = pattern
+          .replace(/\*/g, '.*')  // Convert '*' to '.*' for regex
+          .replace(/\?/g, '.');  // Convert '?' to '.' for regex
+        return new RegExp(`^${regexString}\\s*`, 'i');
+      });
+
+      // Apply each regex pattern to strip the prefix
+      for (const regex of regexPatterns) {
+        cleanedMessage = cleanedMessage.replace(regex, '');
+      }
     }
     return cc.toConventionalChangelogFormat(cc.parser(cleanedMessage));
   }


### PR DESCRIPTION
### Description:
This update introduces a new feature to the Semver GitHub Action, allowing users to specify a list of prefixes to ignore when evaluating commit messages for semantic versioning. This is particularly useful for repositories that use prefixes for integration with tools like Jira.

### Key Changes:

1. New Input prefixIgnoreList:
- Added a new input parameter prefixIgnoreList which accepts a comma-separated list of prefixes.
- The action will strip these prefixes from commit messages before evaluating them for semantic versioning.

2. Commit Message Parsing:
- Updated the parseCommitMessage function to dynamically strip specified prefixes from commit messages.
- Ensures that commit messages are evaluated correctly according to the conventional commit format after prefix removal.

3. Backward Compatibility:
- If prefixIgnoreList is not provided, the action behaves as before, with no changes to commit message evaluation.

### Examples for Using prefixIgnoreList:
Developers can now use regex-like patterns in the prefixIgnoreList to ignore specific prefixes in commit messages. Here are some examples:

1. Exact Match with Wildcards:
- Pattern: ABC-????
- Matches: ABC-1234, ABC-5678
- Does Not Match: ABC-123, ABC-12345

2. Prefix Match with Asterisk:
- Pattern: ABC-*
- Matches: ABC-123, ABC-abc, ABC-1234
- Does Not Match: ABC-123, ABC123

3. Single Character Wildcard:
- Pattern: ABC-12?
- Matches: ABC-123, ABC-124
- Does Not Match: ABC-12, ABC-1234

### Example Commit Messages:
When committing changes, developers should ensure their commit messages align with the conventional commit format, while the specified prefixes will be ignored:

1. Commit Message: ABC-1234 fix: correct typo in documentation
- Result: The prefix ABC-1234 is ignored, and the commit is evaluated as a fix, triggering a patch version bump.

2. Commit Message: ABC-5678 feat: add new API endpoint
- Result: The prefix ABC-5678 is ignored, and the commit is evaluated as a feat, triggering a minor version bump.

3. Commit Message: ABC-1234 chore: update dependencies
- Result: If ABC-* is not in the prefixIgnoreList, the prefix is not ignored, and the commit is evaluated as a chore, which typically does not trigger a version bump.
