### PR TITLE
feat: Add optional fallbackTag input to handle missing latest tags (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,4 +84,4 @@ jobs:
 
 ## :warning: Important :warning:
 
-If no valid latest tag is found and no `fallbackTag` is provided, the job will exit with an error. To avoid this, you can use the `fallbackTag` option to specify a default tag value (e.g., 0.0.0).
+If no valid latest tag is found and no `fallbackTag` is provided, the job will exit with an error. To avoid this, you can use the `fallbackTag` option to specify a default tag value (e.g. `0.0.0`).

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ jobs:
 | `patchList` | Comma separated commit prefixes, used to bump Patch version.                                                                               |         :x:        | `fix, bugfix, perf, refactor, test, tests` |
 | `patchAll`  | If set to `true`, will ignore `patchList` and always count commits as a Patch.                                                             |         :x:        | `false`                                    |
 | `skipInvalidTags` | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest). |         :x:        | `false`                                    |
-| `noVersionBumpBehavior` | Whether to exit with an error *(default)*, a warning, silently, the current version or force bump using patch when none of the commits result in a version bump. (Possible values: `error`, `warn`, `current`, `patch` or `silent`) |         :x:        | `error` |
-| `noNewCommitBehavior` | Whether to exit with an error *(default)*, a warning, the current version or silently when there are no new commits since the latest tag. (Possible values: `error`, `warn`, `current` or `silent`) |         :x:        | `error` |
-| `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. |         :x:        |  |
-| `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: | |
-| `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: | |
-| `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10` |
+| `noVersionBumpBehavior` | Whether to exit with an error *(default)*, a warning, silently, the current version or force bump using patch when none of the commits result in a version bump. (Possible values: `error`, `warn`, `current`, `patch` or `silent`) |         :x:        | `error`                                    |
+| `noNewCommitBehavior` | Whether to exit with an error *(default)*, a warning, the current version or silently when there are no new commits since the latest tag. (Possible values: `error`, `warn`, `current` or `silent`) |         :x:        | `error`                                    |
+| `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. |         :x:        |                                            |
+| `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: |                                            |
+| `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: |                                            |
+| `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10`                                       |
+| `fallbackTag` | A fallback tag to use if no valid latest tag can be found. | :x: | `0.0.0`                                    |
 
 ## Outputs
 
@@ -83,4 +84,4 @@ jobs:
 
 ## :warning: Important :warning:
 
-You must already have an existing tag in your repository. The job will exit with an error if it can't find the latest tag to compare against!
+If no valid latest tag is found and no fallbackTag is provided, the job will exit with an error. To avoid this, you can use the fallbackTag input to specify a default tag value (e.g., 0.0.0).

--- a/README.md
+++ b/README.md
@@ -54,22 +54,22 @@ jobs:
 
 ## Inputs
 
-| Field       | Description                                                                                                                                |      Required      | Default                                    |
-|-------------|--------------------------------------------------------------------------------------------------------------------------------------------|:------------------:|--------------------------------------------|
-| `token`     | Your GitHub token. (e.g. `${{ github.token }}`)                                                                                            | :white_check_mark: |                                            |
-| `branch`    | The branch to use when fetching list of commits to compare against. (e.g. `main`)                                                          |         :x:        | `main`                                     |
-| `majorList` | Comma separated commit prefixes, used to bump Major version. <br>*A `BREAKING CHANGE` note in a commit message will still cause a major bump.* |         :x:        |                                            |
-| `minorList` | Comma separated commit prefixes, used to bump Minor version.                                                                               |         :x:        | `feat, feature`                            |
-| `patchList` | Comma separated commit prefixes, used to bump Patch version.                                                                               |         :x:        | `fix, bugfix, perf, refactor, test, tests` |
-| `patchAll`  | If set to `true`, will ignore `patchList` and always count commits as a Patch.                                                             |         :x:        | `false`                                    |
-| `skipInvalidTags` | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest). |         :x:        | `false`                                    |
-| `noVersionBumpBehavior` | Whether to exit with an error *(default)*, a warning, silently, the current version or force bump using patch when none of the commits result in a version bump. (Possible values: `error`, `warn`, `current`, `patch` or `silent`) |         :x:        | `error`                                    |
-| `noNewCommitBehavior` | Whether to exit with an error *(default)*, a warning, the current version or silently when there are no new commits since the latest tag. (Possible values: `error`, `warn`, `current` or `silent`) |         :x:        | `error`                                    |
-| `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. |         :x:        |                                            |
-| `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: |                                            |
-| `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: |                                            |
-| `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10`                                       |
-| `fallbackTag` | A fallback tag to use if no valid latest tag can be found. | :x: |                                    |
+| Field | Description | Required | Default |
+|---|---|:----:|---|
+| `token` | Your GitHub token. (e.g. `${{ github.token }}`) | :white_check_mark: |  |
+| `branch` | The branch to use when fetching list of commits to compare against. (e.g. `main`) | :x: | `main` |
+| `majorList` | Comma separated commit prefixes, used to bump Major version.  *A `BREAKING CHANGE` note in a commit message will still cause a major bump.* | :x: |  |
+| `minorList` | Comma separated commit prefixes, used to bump Minor version. | :x: | `feat, feature` |
+| `patchList` | Comma separated commit prefixes, used to bump Patch version. | :x: | `fix, bugfix, perf, refactor, test, tests` |
+| `patchAll` | If set to `true`, will ignore `patchList` and always count commits as a Patch. | :x: | `false` |
+| `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: |  |
+| `fallbackTag` | A fallback tag to use if no valid latest tag can be found. | :x: |  |
+| `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: |  |
+| `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10` |
+| `noNewCommitBehavior` | Whether to exit with an error *(default)*, a warning, the current version or silently when there are no new commits since the latest tag. (Possible values: `error`, `warn`, `current` or `silent`) | :x: | `error` |
+| `noVersionBumpBehavior` | Whether to exit with an error *(default)*, a warning, silently, the current version or force bump using patch when none of the commits result in a version bump. (Possible values: `error`, `warn`, `current`, `patch` or `silent`) | :x: | `error` |
+| `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. | :x: |  |
+| `skipInvalidTags` | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest). | :x: | `false` |
 
 ## Outputs
 
@@ -84,4 +84,4 @@ jobs:
 
 ## :warning: Important :warning:
 
-If no valid latest tag is found and no fallbackTag is provided, the job will exit with an error. To avoid this, you can use the fallbackTag input to specify a default tag value (e.g., 0.0.0).
+If no valid latest tag is found and no `fallbackTag` is provided, the job will exit with an error. To avoid this, you can use the `fallbackTag` option to specify a default tag value (e.g., 0.0.0).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ jobs:
 | `additionalCommits` | A list of additional commit messages to parse in order to calculate semver. | :x: |                                            |
 | `fromTag` | Override the tag to use when comparing against the branch in order to fetch the list of commits. | :x: |                                            |
 | `maxTagsToFetch` | Maximum number of tags to fetch from latest. | :x: | `10`                                       |
-| `fallbackTag` | A fallback tag to use if no valid latest tag can be found. | :x: | `0.0.0`                                    |
+| `fallbackTag` | A fallback tag to use if no valid latest tag can be found. | :x: |                                    |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,10 @@ inputs:
     description: Maximum number of tags to fetch from latest.
     required: false
     default: '10'
+  fallbackTag:
+    description: Fallback tag to use if no latest tag is found.
+    required: false
+    default: ''
 outputs:
   current:
     description: Current version number / latest tag.

--- a/index.js
+++ b/index.js
@@ -103,15 +103,13 @@ async function main () {
 
     if (!latestTag) {
       if (fallbackTag && semver.valid(fallbackTag)) {
-        core.info(`Using fallback tag: ${fallbackTag}`);
-        latestTag = { name: fallbackTag };
+        core.info(`Using fallback tag: ${fallbackTag}`)
+        latestTag = { name: fallbackTag }
       } else {
         if (prefix) {
-          return core.setFailed(`None of the ${fetchLimit} latest tags are valid semver or match the specified prefix!`);
+          return core.setFailed(`None of the ${fetchLimit} latest tags are valid semver or match the specified prefix!`)
         } else {
-          return core.setFailed(skipInvalidTags
-            ? `None of the ${fetchLimit} latest tags are valid semver!`
-            : 'Latest tag is invalid (does not conform to semver)!');
+          return core.setFailed(skipInvalidTags ? `None of the ${fetchLimit} latest tags are valid semver!` : 'Latest tag is invalid (does not conform to semver)!')
         }
       }
     }


### PR DESCRIPTION
This PR introduces a new optional input parameter, fallbackTag, to address scenarios where no valid latest tag is found in the repository. If provided, the action will use the specified fallback tag as the base for calculating the next version.

Key updates:

Added fallbackTag input to the action configuration.
Updated the logic to check and use the fallback tag if no valid latest tag is available.
Enhanced error handling to ensure graceful fallback or informative error messages.
Updated the README to document the new input parameter and provide usage examples.
This change resolves issue #52 