### PR TITLE
fix: when 'patchAll' is set, always bump patch version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -53158,9 +53158,9 @@ async function main () {
     }
   }
 
-  // PARSE COMMITS
   let bump = null
   if (!bumpTypes.patchAll) {
+    // PARSE COMMITS
     const majorChanges = []
     const minorChanges = []
     const patchChanges = []

--- a/dist/index.js
+++ b/dist/index.js
@@ -53190,7 +53190,6 @@ async function main () {
       }
     }
 
-    let bump = null
     if (majorChanges.length > 0) {
       bump = 'major'
     } else if (minorChanges.length > 0) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -53159,66 +53159,72 @@ async function main () {
   }
 
   // PARSE COMMITS
-
-  const majorChanges = []
-  const minorChanges = []
-  const patchChanges = []
-  for (const commit of commits) {
-    try {
-      const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
-      if (bumpTypes.major.includes(cAst.type)) {
-        majorChanges.push(commit.commit.message)
-        core.info(`[MAJOR] Commit ${commit.sha} of type ${cAst.type} will cause a major version bump.`)
-      } else if (bumpTypes.minor.includes(cAst.type)) {
-        minorChanges.push(commit.commit.message)
-        core.info(`[MINOR] Commit ${commit.sha} of type ${cAst.type} will cause a minor version bump.`)
-      } else if (bumpTypes.patchAll || bumpTypes.patch.includes(cAst.type)) {
-        patchChanges.push(commit.commit.message)
-        core.info(`[PATCH] Commit ${commit.sha} of type ${cAst.type} will cause a patch version bump.`)
-      } else {
-        core.info(`[SKIP] Commit ${commit.sha} of type ${cAst.type} will not cause any version bump.`)
-      }
-      for (const note of cAst.notes) {
-        if (note.title === 'BREAKING CHANGE') {
+  let bump = null
+  if (!bumpTypes.patchAll) {
+    const majorChanges = []
+    const minorChanges = []
+    const patchChanges = []
+    for (const commit of commits) {
+      try {
+        const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
+        if (bumpTypes.major.includes(cAst.type)) {
           majorChanges.push(commit.commit.message)
-          core.info(`[MAJOR] Commit ${commit.sha} has a BREAKING CHANGE mention, causing a major version bump.`)
+          core.info(`[MAJOR] Commit ${commit.sha} of type ${cAst.type} will cause a major version bump.`)
+        } else if (bumpTypes.minor.includes(cAst.type)) {
+          minorChanges.push(commit.commit.message)
+          core.info(`[MINOR] Commit ${commit.sha} of type ${cAst.type} will cause a minor version bump.`)
+        } else if (bumpTypes.patch.includes(cAst.type)) {
+          patchChanges.push(commit.commit.message)
+          core.info(`[PATCH] Commit ${commit.sha} of type ${cAst.type} will cause a patch version bump.`)
+        } else {
+          core.info(`[SKIP] Commit ${commit.sha} of type ${cAst.type} will not cause any version bump.`)
+        }
+        for (const note of cAst.notes) {
+          if (note.title === 'BREAKING CHANGE') {
+            majorChanges.push(commit.commit.message)
+            core.info(`[MAJOR] Commit ${commit.sha} has a BREAKING CHANGE mention, causing a major version bump.`)
+          }
+        }
+      } catch (err) {
+        core.info(`[INVALID] Skipping commit ${commit.sha} as it doesn't follow conventional commit format.`)
+      }
+    }
+
+    let bump = null
+    if (majorChanges.length > 0) {
+      bump = 'major'
+    } else if (minorChanges.length > 0) {
+      bump = 'minor'
+    } else if (patchChanges.length > 0) {
+      bump = 'patch'
+    } else {
+      switch (noVersionBumpBehavior) {
+        case 'current': {
+          core.info('No commit resulted in a version bump since last release! Exiting with current as next version...')
+          outputVersion(semver.clean(latestTag.name))
+          return
+        }
+        case 'patch': {
+          core.info('No commit resulted in a version bump since last release! Defaulting to using PATCH...')
+          bump = 'patch'
+          break
+        }
+        case 'silent': {
+          return core.info('No commit resulted in a version bump since last release! Exiting silently...')
+        }
+        case 'warn': {
+          return core.warning('No commit resulted in a version bump since last release!')
+        }
+        default: {
+          return core.setFailed('No commit resulted in a version bump since last release!')
         }
       }
-    } catch (err) {
-      core.info(`[INVALID] Skipping commit ${commit.sha} as it doesn't follow conventional commit format.`)
     }
-  }
-
-  let bump = null
-  if (majorChanges.length > 0) {
-    bump = 'major'
-  } else if (minorChanges.length > 0) {
-    bump = 'minor'
-  } else if (patchChanges.length > 0) {
-    bump = 'patch'
   } else {
-    switch (noVersionBumpBehavior) {
-      case 'current': {
-        core.info('No commit resulted in a version bump since last release! Exiting with current as next version...')
-        outputVersion(semver.clean(latestTag.name))
-        return
-      }
-      case 'patch': {
-        core.info('No commit resulted in a version bump since last release! Defaulting to using PATCH...')
-        bump = 'patch'
-        break
-      }
-      case 'silent': {
-        return core.info('No commit resulted in a version bump since last release! Exiting silently...')
-      }
-      case 'warn': {
-        return core.warning('No commit resulted in a version bump since last release!')
-      }
-      default: {
-        return core.setFailed('No commit resulted in a version bump since last release!')
-      }
-    }
+    bump = 'patch'
+    core.info('patchAll is set to true, all commits will be considered for a patch version bump.')
   }
+  
   core.info(`\n>>> Will bump version ${prefix}${latestTag.name} using ${bump.toUpperCase()}\n`)
   core.setOutput('bump', bump || 'none')
 

--- a/index.js
+++ b/index.js
@@ -214,10 +214,9 @@ async function main () {
     }
   }
 
-  // PARSE COMMITS
-
   let bump = null
   if (!bumpTypes.patchAll) {
+    // PARSE COMMITS
     const majorChanges = []
     const minorChanges = []
     const patchChanges = []


### PR DESCRIPTION
### Pull Request Description

#### Summary
This PR addresses an issue with the `patchAll` option in the versioning workflow. Previously, the `patchAll` option did not skip the conventional commits version bump logic, which could result in unintended version increments (e.g., minor or major bumps). This fix ensures that the `patchAll` option always applies a **patch version bump**, regardless of the commit messages or conventional commit rules.

#### Changes Made
- Updated the logic for the `patchAll` option to bypass conventional commit checks entirely.
- Ensured that when `patchAll` is enabled, the version bump is always a patch increment (`x.x.(y+1)`).

#### Testing
- Verified that enabling `patchAll` results in a patch version bump, even when conventional commit messages suggest a minor or major bump.
- Confirmed that disabling `patchAll` restores the default behavior of versioning based on conventional commits.
