### PR TITLE
feat: add `scopeFilter` option (e.g. for monorepos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ jobs:
 | `prefix` | A prefix that will be striped when parsing tags (e.g. `foobar/`). Any other prefix will be ignored. Useful for monorepos. The prefix will be added back to the output values. | :x: |  |
 | `skipInvalidTags` | If set to `true`, will skip tags that are not valid semver until it finds a proper one (up to `maxTagsFetch` from latest). | :x: | `false` |
 | `tagFilter` | If defined, only tags matching the regex pattern will be included (e.g. `^[a-f0-9.]+$`). Use a negative lookahead match to exclude tags (e.g. `^(?!abcd).*$`). When used in conjunction with the prefix option, the prefix is striped first, then the filter is applied. | :x: |  |
+| `scopeFilter` | Comma-separated list of scopes to include. When set, only commits whose conventional-commit scope matches one of these values will be considered. Leave empty to consider all scopes. Useful for monorepos. | :x: |  |
 
 ## Outputs
 
@@ -82,6 +83,27 @@ jobs:
 | `nextMajor`       | Next version major number in format `v0`                    | `v1`          |
 | `nextMajorStrict` | Next version major number only.                             | `1`           |
 | `bump`            | Next version behavior: `major`, `minor`, `patch` or `none`. | `minor`       |
+
+## Using scopeFilter for Monorepos
+
+If you set `scopeFilter` to a comma-separated list of scopes (for example `cli,api`) the action will only consider commits with those scopes when calculating the next version. This is useful in monorepos where you want to run per-package releases.
+
+Example:
+
+```yaml
+uses: ietf-tools/semver-action@v1
+with:
+  token: ${{ secrets.GITHUB_TOKEN }}
+  branch: main
+  prefix: 'cli-v'
+  minorList: feat
+  patchList: fix
+  scopeFilter: cli
+```
+
+**Notes:**
+- `scopeFilter` does an exact match against the parsed conventional-commit scope (after trimming). A commit without a scope is treated as an empty scope.
+- If `scopeFilter` is empty (default), behavior is unchanged and all commits are considered.
 
 ## :warning: Important :warning:
 

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: If defined, only tags matching the regex pattern will be included (e.g. `^[a-f0-9.]+$`). Use a negative lookahead match to exclude tags (e.g. `^(?!abcd).*$`). When used in conjunction with the prefix option, the prefix is striped first, then the filter is applied.
     required: false
     default: ''
+  scopeFilter:
+    description: "Comma-separated list of scopes to include. When set, only commits whose conventional-commit scope matches one of these values will be considered. Leave empty to consider all scopes."
+    required: false
+    default: ''
 outputs:
   current:
     description: Current version number / latest tag.

--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ async function main () {
   const fallbackTag = core.getInput('fallbackTag')
   const tagFilter = core.getInput('tagFilter')
 
+  // NEW: read scopeFilter input (comma-separated list of scopes). Empty = no filtering
+  const scopeFilterRaw = core.getInput('scopeFilter') || ''
+  const scopeFilter = scopeFilterRaw.split(',').map(s => s.trim()).filter(s => s !== '')
+
   const bumpTypes = {
     major: core.getInput('majorList').split(',').map(p => p.trim()).filter(p => p),
     minor: core.getInput('minorList').split(',').map(p => p.trim()).filter(p => p),
@@ -222,6 +226,16 @@ async function main () {
   for (const commit of commits) {
     try {
       const cAst = cc.toConventionalChangelogFormat(cc.parser(commit.commit.message))
+
+      // If scopeFilter is set, only consider commits whose parsed scope matches one of the requested scopes
+      if (scopeFilter && scopeFilter.length > 0) {
+        const commitScope = (cAst.scope || '').toString()
+        if (!scopeFilter.includes(commitScope)) {
+          core.info(`[SKIP] Commit ${commit.sha} has scope '${commitScope || '<none>'}' which does not match scopeFilter='${scopeFilter.join(',')}'`)
+          continue
+        }
+      }
+
       if (bumpTypes.major.includes(cAst.type)) {
         majorChanges.push(commit.commit.message)
         core.info(`[MAJOR] Commit ${commit.sha} of type ${cAst.type} will cause a major version bump.`)


### PR DESCRIPTION
This pull request adds support for filtering commits by scope in a monorepo setup using a new `scopeFilter` input. This allows the action to consider only commits with specified conventional-commit scopes when determining the next version, making per-package releases easier. Documentation has been updated to explain the new feature and its usage.

### Feature Addition: Scope Filtering

* Added a new `scopeFilter` input to `action.yml` that accepts a comma-separated list of scopes to include when processing commits. If left empty, all scopes are considered.
* Updated `index.js` to read and process the `scopeFilter` input, splitting it into an array and trimming values.
* Modified commit processing logic in `index.js` to skip commits whose scope does not match any value in `scopeFilter`, logging skipped commits for clarity.

### Documentation Updates

* Added `scopeFilter` to the options table in the `README.md`, describing its purpose and usage.
* Included a new section in the `README.md` with usage examples and notes explaining how `scopeFilter` works and its effect on commit selection.